### PR TITLE
Backend error handling for identification and details services

### DIFF
--- a/backend_python/src/app/api/endpoints/plant_details_rhs.py
+++ b/backend_python/src/app/api/endpoints/plant_details_rhs.py
@@ -1,23 +1,23 @@
-from fastapi import APIRouter
-from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from fastapi import APIRouter, status
+from app.models import PlantDetailRequest, PlantDetailResponse
 from app.services import PlantDetailsRhsService
 import logging
+
 logger = logging.getLogger(__name__)
 
-router = APIRouter()
+# Router endpoint
+router = APIRouter(
+    tags=["garden_glossary"],
+)
 
-class PlantRequest(BaseModel):
-    plant: str
-
-@router.post("/plant-details-rhs/")
-async def plant_details(request: PlantRequest):
+@router.post(
+    "/plant-details-rhs/",
+    response_model=PlantDetailResponse,
+    summary="Extract key cultivation details about a plant from the RHS website",
+    status_code=status.HTTP_200_OK
+)
+async def plant_details(request: PlantDetailRequest):
     service = PlantDetailsRhsService()
     details = await service.retrieve_plant_details(request.plant)
-    logger.info(f'details: {details}')
-
-    return JSONResponse(
-        content={'details': details},
-        media_type='application/json',
-        )
+    return PlantDetailResponse(details=details)
 

--- a/backend_python/src/app/exceptions/__init__.py
+++ b/backend_python/src/app/exceptions/__init__.py
@@ -1,0 +1,1 @@
+from .exceptions import PlantServiceErrorCode, PlantServiceException

--- a/backend_python/src/app/exceptions/exceptions.py
+++ b/backend_python/src/app/exceptions/exceptions.py
@@ -1,0 +1,51 @@
+"""
+Exceptions module for plant service operations.
+
+This module contains all custom exceptions and error codes used across the plant services, 
+providing a centralised location for error handling and documentation.
+"""
+
+from enum import Enum
+from typing import Optional, Dict, Any
+from fastapi import status
+
+class PlantServiceErrorCode(Enum):
+    """Enumeration of possible error codes."""
+    
+    SCRAPER_INITIALIZATION = "SCRAPER_INIT_001"
+    BROWSER_ERROR = "BROWSER_002"
+    COOKIE_CONSENT_FAILED = "COOKIE_003"
+    NO_RESULTS_FOUND = "SEARCH_004"
+    PARSING_ERROR = "PARSE_005"
+    NETWORK_ERROR = "NETWORK_006"
+    VALIDATION_ERROR = "VALIDATION_007"
+    TIMEOUT_ERROR = "TIMEOUT_008"
+    SERVICE_ERROR = "SERVICE_009"
+    ELEMENT_ERROR = "ELEMENT_010"
+
+class PlantServiceException(Exception):
+    """
+    Custom exception for handling errors in plant services.
+
+    Attributes:
+        error_code (PlantServiceErrorCode): The error code enum value
+        message (str): Summary error message
+        status_code (int): HTTP status code
+        details (Optional[Dict[str, Any]]): Detailed error message
+    """
+    def __init__(
+        self,
+        error_code: PlantServiceErrorCode,
+        message: str,
+        status_code: int = status.HTTP_500_INTERNAL_SERVER_ERROR,
+        details: Optional[Dict[str, Any]] = None
+    ):
+        self.error_code = error_code
+        self.message = message
+        self.status_code = status_code
+        self.details = details or {}
+        super().__init__(self.message)
+
+    def __str__(self):
+        return f"{self.error_code.value}: {self.message}"
+

--- a/backend_python/src/app/main.py
+++ b/backend_python/src/app/main.py
@@ -1,8 +1,11 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from app.models import ErrorResponse
 from app.api.endpoints import plant_identification, plant_details_rhs
+from app.exceptions import PlantServiceException
 import logging
-from app.core.logging import setup_logging  
+from app.core.logging import setup_logging
 import uvicorn
 
 def create_application() -> FastAPI:
@@ -10,17 +13,40 @@ def create_application() -> FastAPI:
     setup_logging()
     logger = logging.getLogger(__name__)
 
-    app = FastAPI()
+    app = FastAPI(
+        title="Garden Glossary API",
+        description="""
+        # 🌱 API service for identifying a plant from an image and providing cultivation details.
+        
+        ## Features:
+        * identify-plant: Passes an uploaded image and 'organ' to the PlantNet API, to return the 3 most likely species matches.
+        * plant-details-rhs: Searches RHS website for requested plant species and returns key cultivation details.
+        * plant-details-llm: Fallback service if plant-details-rhs fails - calls ChatGPT API to return plant details in same style and format as plant-details-rhs service.
+        """
+    )
     
     # Add CORS middleware to allow requests from mobile app
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],  # Allows all origins
+        allow_origins=["*"],
         allow_credentials=True,
-        allow_methods=["*"],  # Allows all methods
-        allow_headers=["*"],  # Allows all headers
+        allow_methods=["*"],
+        allow_headers=["*"],
     )
 
+    # Register exception handler
+    @app.exception_handler(PlantServiceException)
+    async def plant_service_exception_handler(request: Request, exc: PlantServiceException):
+        logger.error(f"PlantServiceException:  {exc.error_code.value} - {exc.message}")
+        return JSONResponse(
+            status_code=exc.status_code,
+            content=ErrorResponse(
+                error_code=exc.error_code,
+                message=exc.message,
+                details=exc.details
+            ).model_dump()
+        )
+ 
     # Include routers
     app.include_router(plant_identification.router, prefix="/api/v1")
     app.include_router(plant_details_rhs.router, prefix="/api/v1")

--- a/backend_python/src/app/models/__init__.py
+++ b/backend_python/src/app/models/__init__.py
@@ -1,0 +1,2 @@
+from .api import Organ, Match, PlantIdentificationResponse, PlantDetailRequest, PlantDetailResponse, ErrorResponse
+from .domain import Size, Soil, Position, PlantDetails

--- a/backend_python/src/app/models/api.py
+++ b/backend_python/src/app/models/api.py
@@ -1,0 +1,122 @@
+from pydantic import BaseModel, Field
+from typing import Optional, Dict, Any, List
+from enum import Enum
+
+class Organ(str, Enum):
+    """Enumeration of possible organs to pass to PlantNet API."""
+    leaf = "leaf"
+    flower = "flower"
+    fruit = "fruit"
+    bark = "bark"
+    auto = "auto"
+
+class Match(BaseModel):
+    """
+    Model for individual plant identification matches, to be returned to the frontend.
+
+    Attributes:
+        species (str): Name of identified species
+        genus (str): Name of identified genus
+        score (float): Probability of identification being correct
+        commonNames (List[str]): List of common names for identified species 
+    """
+    species: str
+    genus: str
+    score: float
+    commonNames: List[str]
+
+class PlantIdentificationResponse(BaseModel):
+    """
+    Response model for 'Plant Identification' service.
+
+    Attributes:
+        matches (Dict[int, Match]): List of possible identified matches
+    """
+    matches: Dict[int, Match]
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "status_code": 200,
+                "matches": {
+                    0: {
+                        'species': 'Tulipa gesneriana', 
+                        'genus': 'Tulipa', 
+                        'score': 0.82973, 
+                        'commonNames': ["Didier's tulip", 'Garden tulip', 'Tulip']
+                    }, 
+                    1: {
+                        'species': 'Tulipa kaufmanniana', 
+                        'genus': 'Tulipa', 
+                        'score': 0.02704, 
+                        'commonNames': ['Water-lily tulip', "Kaufmann's Tulip"]
+                    }, 
+                    2: {
+                        'species': 'Tulipa fosteriana', 
+                        'genus': 'Tulipa', 
+                        'score': 0.01164, 
+                        'commonNames': []
+                    }
+                }
+            }
+        }
+
+class PlantDetailRequest(BaseModel):
+    """
+    Request model for 'Plant Details' endpoint input validation.
+
+    Attributes:
+        field (str): Name of plant species 
+    """
+    plant: str = Field(..., min_length=1, description="Name of the plant species to search for")
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "plant": "tulipa gesneriana"
+            }
+        }
+
+class PlantDetailResponse(BaseModel):
+    """
+    Response model for 'Plant Details' services.
+
+    Attributes:
+        details (Dict[str, Any]): Dictionary of detailed information on the plant.
+    """
+    details: Dict[str, Any]
+
+    class Config:
+        json_schema_extra = {
+            "example": {
+                "details": {
+                    "size": {
+                        "height": "0.1-0.5 metres",
+                        "spread": "0.1-0.5 metres",
+                        "time_to_height": "1 year"
+                    },
+                    "hardiness": "H6: hardy in all of UK and northern Europe (-20 to -15)",
+                    "soil": {
+                        "types": ["Chalk", "Clay", "Loam", "Sand"],
+                        "moisture": ["Moist but well-drained"],
+                        "ph_levels": ["Acid"]
+                    },
+                    "position": {
+                        "sun": "Full sun",
+                        "aspect": "South-facing or West-facing",
+                        "exposure": "Sheltered"
+                    },
+                    "cultivation_tips": "Plant in autumn, at a depth of...",
+                    "pruning": "Deadhead after flowering and remove fallen petals."
+                }
+            }
+        }
+
+class ErrorResponse(BaseModel):
+    """
+    Response model for errors in API services, to be returned to the frontend in a JSONResponse.
+    """
+    error_code: str
+    message: str
+    details: Optional[Dict[str, Any]] = None
+

--- a/backend_python/src/app/models/domain.py
+++ b/backend_python/src/app/models/domain.py
@@ -1,0 +1,123 @@
+from dataclasses import dataclass, asdict
+from typing import Optional, Dict, List, Any
+from fastapi import status
+from app.exceptions import PlantServiceException, PlantServiceErrorCode
+
+@dataclass
+class Size:
+    """
+    Dataclass for 'Size' information on plant.
+
+    Attributes:
+        height (str): Ultimate height of plant
+        spread (str): Ultimate spread of plant
+        time_to_height (str): Time taken for plant to reach ultimate height
+
+    Methods:
+        to_dict: Convert information into Dict, raise PlantServiceException if error
+    """
+    height: Optional[str] = None
+    spread: Optional[str] = None
+    time_to_height: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        try:
+            return {k: v for k, v in asdict(self).items() if v is not None}
+        except Exception as e:
+            raise PlantServiceException(
+                error_code=PlantServiceErrorCode.PARSING_ERROR,
+                message="Failed to convert data class to dictionary",
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                details={"class": self.__class__.__name__, "error": str(e)}
+            )
+
+@dataclass
+class Soil:
+    """
+    Dataclass for 'Soil' growing conditions for plant.
+
+    Attributes:
+        types (List[str]): List of soil types the plant can grow in (e.g. 'Chalk')
+        moisture (List[str]): List of descriptors for moisture levels the plant can grow in (e.g. 'Well-drained')
+        ph_levels (List[str]): List of pH bands the plant can grow in (e.g. 'Acidic')
+
+    Methods:
+        to_dict: Convert information into Dict, raise PlantServiceException if error
+    """
+    types: List[str]
+    moisture: List[str]
+    ph_levels: List[str]
+
+    def to_dict(self) -> Dict[str, Any]:
+        try:
+            return {k: v for k, v in asdict(self).items() if v is not None}
+        except Exception as e:
+            raise PlantServiceException(
+                error_code=PlantServiceErrorCode.PARSING_ERROR,
+                message="Failed to convert data class to dictionary",
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                details={"class": self.__class__.__name__, "error": str(e)}
+            )
+
+@dataclass
+class Position:
+    """
+    Dataclass for 'Position' information on plant.
+
+    Attributes:
+        sun (str): Type of sun exposure plant should grow in (e.g. 'Full sun')
+        aspect (str): Direction of sunlight plant should be exposed to (e.g. 'West-facing')
+        exposure (str): 
+
+    Methods:
+        to_dict: Convert information into Dict, raise PlantServiceException if error
+    """
+    sun: Optional[str] = None
+    aspect: Optional[str] = None
+    exposure: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        try:
+            return {k: v for k, v in asdict(self).items() if v is not None}
+        except Exception as e:
+            raise PlantServiceException(
+                error_code=PlantServiceErrorCode.PARSING_ERROR,
+                message="Failed to convert data class to dictionary",
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                details={"class": self.__class__.__name__, "error": str(e)}
+            )
+
+@dataclass
+class PlantDetails:
+    """
+    Dataclass containing all detailed information on plant.
+
+    Attributes:
+        size (Size): 'Size' object with information on ultimate plant size
+        hardiness (str): RHS Hardiness rating and descriptor
+        soil (Soil): 'Soil' object with information on soil requirements for plant
+        position (Position): 'Position' object with information on plant sunlight and shelter
+        cultivation_tips (str): RHS tips on cultivation
+        pruning (str): RHS tips on pruning
+
+    Methods:
+        to_dict: Convert information into Dict, raise PlantServiceException if error
+    """
+    size: Optional[Size] = None
+    hardiness: Optional[str] = None
+    soil: Optional[Soil] = None
+    position: Optional[Position] = None
+    cultivation_tips: Optional[str] = None
+    pruning: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        try:
+            return {k: v for k, v in asdict(self).items() if v is not None}
+        except Exception as e:
+            raise PlantServiceException(
+                error_code=PlantServiceErrorCode.PARSING_ERROR,
+                message="Failed to convert data class to dictionary",
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                details={"class": self.__class__.__name__, "error": str(e)}
+            )
+        

--- a/backend_python/src/app/services/plant_details_rhs.py
+++ b/backend_python/src/app/services/plant_details_rhs.py
@@ -1,98 +1,75 @@
+"""Service to extract key cultivation details about a plant from the RHS website."""
+
 import asyncio
-from fastapi import HTTPException
-from dataclasses import dataclass, asdict
-from typing import Optional, List, Dict, Any
-from selenium import webdriver
+from fastapi import status
+from app.utils import create_driver, CookieConsentHandler
+from app.models import Size, Soil, Position, PlantDetails
+from app.exceptions import PlantServiceErrorCode, PlantServiceException
+from typing import Optional, List
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
-from selenium.common.exceptions import TimeoutException, ElementNotInteractableException
+from selenium.common.exceptions import  (
+    StaleElementReferenceException, 
+    TimeoutException, 
+    WebDriverException
+    )
 from bs4 import BeautifulSoup
-from contextlib import contextmanager
 import logging
+
 logger = logging.getLogger(__name__)
 
-@dataclass
-class Size:
-    height: Optional[str] = None
-    spread: Optional[str] = None
-    time_to_height: Optional[str] = None
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {k: v for k, v in asdict(self).items() if v is not None}
-
-@dataclass
-class Soil:
-    types: List[str]
-    moisture: List[str]
-    ph_levels: List[str]
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {k: v for k, v in asdict(self).items() if v is not None}
-
-@dataclass
-class Position:
-    sun: Optional[str] = None
-    aspect: Optional[str] = None
-    exposure: Optional[str] = None
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {k: v for k, v in asdict(self).items() if v is not None}
-
-@dataclass
-class PlantDetails:
-    size: Optional[Size] = None
-    hardiness: Optional[str] = None
-    soil: Optional[Soil] = None
-    position: Optional[Position] = None
-    cultivation_tips: Optional[str] = None
-    pruning: Optional[str] = None
-
-    def to_dict(self) -> Dict[str, Any]:
-        return {k: v for k, v in asdict(self).items() if v is not None}
-
-class CookieConsentHandler:
-    BUTTON_CONFIGS = [
-        {"by": By.ID, "value": "onetrust-accept-btn-handler"},
-        {"by": By.CLASS_NAME, "value": "onetrust-close-btn-handler"},
-        {"by": By.CSS_SELECTOR, "value": "button[aria-label='Close']"}
-    ]
-
-    @classmethod
-    def handle(cls, driver: webdriver.Chrome, timeout: int=3) -> bool:
-        for config in cls.BUTTON_CONFIGS:
-            try:
-                button = WebDriverWait(driver, timeout).until(
-                    EC.element_to_be_clickable((config["by"], config["value"]))
-                )
-                button.click()
-                logger.info(f"Successfully clicked cookie consent button: {config['value']}")
-                return True
-            except (TimeoutException, ElementNotInteractableException):
-                logger.debug(f"Could not find cookie button: {config['value']}")
-                continue
-        
-        logger.warning("Could not handle cookie consent - no matching buttons found")
-        return False
-
-@contextmanager
-def create_driver():
-    driver = webdriver.Chrome()
-    try:
-        driver.maximize_window()
-        yield driver
-    finally:
-        driver.quit()
-
 class PlantScraper:
+    """
+    A web scraper for extracting plant details from the RHS website.
+
+    Uses Selenium WebDriver for dynamic content and BeautifulSoup for parsing.
+    
+    Args:
+        base_url (str): The base URL for RHS plant search queries.
+    
+    Raises:
+        PlantServiceException: If base_url is empty or invalid.
+    """
     def __init__(self, base_url: str):
+        if not base_url:
+            raise PlantServiceException(
+                error_code=PlantServiceErrorCode.SCRAPER_INITIALIZATION,
+                message="Base URL cannot be empty",
+                status_code=status.HTTP_400_BAD_REQUEST
+            )
         self.base_url = base_url
 
     def _find_plant_details(self, soup: BeautifulSoup, selector: str) -> Optional[BeautifulSoup]:
-        panel = soup.find('h6', string=selector)
-        return panel.find_parent('div', class_='plant-attributes__panel') if panel else None
+        """
+        Locate parent div for specific section within the parsed HTML.
+        
+        Args:
+            soup (BeautifulSoup): Parsed HTML from the RHS website.
+            selector (str): Name of the section title (H6) to search for.
+
+        Returns:
+            Optional[BeautifulSoup]: Soup for the section if title found, None otherwise.
+        """
+        try:
+            panel = soup.find('h6', string=selector)
+            return panel.find_parent('div', class_='plant-attributes__panel') if panel else None
+        except AttributeError:
+            raise PlantServiceException(
+                error_code=PlantServiceErrorCode.PARSING_ERROR,
+                message=f"Failed to parse {selector} section",
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
     
     def _extract_size(self, soup: BeautifulSoup) -> Optional[Size]:
+        """
+        Extract plant size information from the parsed HTML.
+        
+        Args:
+            soup (BeautifulSoup): Parsed HTML containing size information.
+
+        Returns:
+            Optional[Size]: Size details if found, None otherwise.
+        """
         size_panel = self._find_plant_details(soup, 'Size')
         if not size_panel:
             return None
@@ -104,6 +81,15 @@ class PlantScraper:
         )
     
     def _extract_hardiness(self, soup: BeautifulSoup) -> Optional[str]:
+        """
+        Extract plant hardiness from the parsed HTML.
+
+        Args:
+            soup (BeautifulSoup): Parsed HTML containing hardiness information.
+
+        Returns:
+            Optional[str]: Hardiness rating and desriptor if found, None otherwise.
+        """
         pos_panel = self._find_plant_details(soup, 'Position')
         if not pos_panel:
             return None
@@ -119,6 +105,15 @@ class PlantScraper:
         return None
     
     def _extract_soil(self, soup: BeautifulSoup) -> Optional[Soil]:
+        """
+        Extract soil requirements from the parsed HTML.
+
+        Args:
+            soup (BeautifulSoup): Parsed HTML containing soil information.
+
+        Returns:
+            Optional[Soil]: Soil requirements if found, None otherwise.
+        """
         gc_panel = self._find_plant_details(soup, 'Growing conditions')
         if not gc_panel:
             return None
@@ -144,6 +139,16 @@ class PlantScraper:
         return None
     
     def _extract_list_field(self, panel: BeautifulSoup, field_name: str) -> List[str]:
+        """
+        Extract a field with multiple strings from a panel.
+
+        Args:
+            panel (BeautifulSoup): Panel containing the field.
+            field_name (str): Name of the field to extract.
+
+        Returns:
+            List[str]: Field values if found, None otherwise.
+        """
         field_h6 = panel.find('h6', string=field_name)
         if not field_h6:
             return []
@@ -157,6 +162,15 @@ class PlantScraper:
                 if span.text.strip()]
     
     def _extract_position(self, soup: BeautifulSoup) -> Optional[Position]:
+        """
+        Extract position and sunlight requirements from the parsed HTML.
+
+        Args:
+            soup (BeautifulSoup): Parsed HTML containing position information.
+
+        Returns:
+            Optional[Position]: Position requirements if found, None otherwise.
+        """
         pos_panel = self._find_plant_details(soup, 'Position')
         if not pos_panel:
             return None
@@ -187,6 +201,15 @@ class PlantScraper:
         return position if (position.sun or position.aspect or position.exposure) else None
     
     def _extract_cultivation_tips(self, soup: BeautifulSoup) -> Optional[str]:
+        """
+        Extract cultivation tips from the parsed HTML.
+
+        Args:
+            soup (BeautifulSoup): Parsed HTML containing cultivation information.
+
+        Returns:
+            Optional[str]: Cultivation tips if found, None otherwise.
+        """
         cult_h5 = soup.find('h5', string='Cultivation')
         if not cult_h5:
             return None
@@ -209,6 +232,15 @@ class PlantScraper:
         return ''.join(text_parts) if text_parts else None
     
     def _extract_pruning(self, soup: BeautifulSoup) -> Optional[str]:
+        """
+        Extract pruning tips from the parsed HTML.
+
+        Args:
+            soup (BeautifulSoup): Parsed HTML containing pruning information.
+
+        Returns:
+            Optional[str]: Pruning tips if found, None otherwise.
+        """
         pruning_h5 = soup.find('h5', string='Pruning')
         if not pruning_h5:
             return None
@@ -221,6 +253,16 @@ class PlantScraper:
         return p_tag.text.strip() if p_tag and p_tag.text else None
     
     def _extract_field(self, panel: BeautifulSoup, field_name: str) -> Optional[str]:
+        """
+        Extract a single field value from a panel.
+
+        Args:
+            panel (BeautifulSoup): Panel containing the field.
+            field_name (str): Name of the field to extract.
+
+        Returns:
+            Optional[str]: Field value if found, None otherwise.
+        """
         field_div = panel.find('h6', string=field_name)
         if field_div:
             parent_div = field_div.find_parent('div', class_='flag__body')
@@ -228,50 +270,162 @@ class PlantScraper:
         return None
     
     def get_plant_details(self, species: str) -> Optional[PlantDetails]:
-        species_query = species.replace(" ", "%20").lower()
-        url = f"{self.base_url}{species_query}"
+        """
+        Retrieve detailed information about a plant species from the RHS website.
 
-        with create_driver() as driver:
-            try:
-                driver.get(url)
+        Args:
+            species (Str): The plant species name to search for.
+
+        Returns:
+            Optional[PlantDetails]: Plant details if found, None otherwise
+        
+        Raises:
+            PlantServiceException: If species is empty, network error occurs, or parsing fails.
+        """
+        try:
+            if not species:
+                raise PlantServiceException(
+                    error_code=PlantServiceErrorCode.VALIDATION_ERROR,
+                    message="Species name cannot be empty",
+                    status_code=status.HTTP_400_BAD_REQUEST
+                )
+
+            species_query = species.replace(" ", "%20").lower()
+            url = f"{self.base_url}{species_query}"
+
+            with create_driver() as (driver, wait):
+                try:
+                    driver.get(url)
+                except WebDriverException as e:
+                    raise PlantServiceException(
+                        error_code=PlantServiceErrorCode.NETWORK_ERROR,
+                        message=f"Failed to access RHS website at {url}",
+                        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                        details={"error": str(e)}
+                    )
+                
+                # Handle cookie consent
+                logger.info("About to handle cookie consent")
                 if not CookieConsentHandler.handle(driver):
-                    raise Exception("Failed to handle cookie consent")
+                    raise PlantServiceException(
+                        error_code=PlantServiceErrorCode.COOKIE_CONSENT_FAILED,
+                        message="Failed to handle cookie consent",
+                        status_code=status.HTTP_503_SERVICE_UNAVAILABLE
+                    )
                 
                 # Scroll to bottom and find matching result
-                driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
-                wait = WebDriverWait(driver, 5)
-
-                search_results = wait.until(
-                    EC.presence_of_all_elements_located((
-                        By.CSS_SELECTOR, 'app-plant-search-list a.u-faux-block-link__overlay'
-                    ))
-                )
+                try:
+                    driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
+                    search_results = wait.until(
+                        EC.presence_of_all_elements_located((
+                            By.CSS_SELECTOR, 'app-plant-search-list a.u-faux-block-link__overlay'
+                        ))
+                    )
+                except TimeoutException:
+                    raise PlantServiceException(
+                        error_code=PlantServiceErrorCode.NO_RESULTS_FOUND,
+                        message=f"No search results found for species '{species}'",
+                        status_code=status.HTTP_404_NOT_FOUND
+                    )
 
                 match_found = False
+
+                # Check for strict match and click
                 for result in search_results:
                     if species.lower() == result.get_attribute('innerText').strip().lower():
-                        result.click()
                         match_found = True
+                        logger.info(f"Match found for species: '{species}'")
+                        result.click()
                         break
                 
+                # If no strict match, check for "species + (" and click
+                if not match_found:
+                    for result in search_results:
+                        # logger.info(f"{result.get_attribute('innerText')}")
+                        if f"{species.lower()} (" in result.get_attribute('innerText').lower():
+                            match_found = True
+                            logger.info(f"'Bracket match' found for species '{species}'")
+                            result.click()
+                            break
+                
+                # If no match, raise Exception
                 if not match_found:
                     logger.warning(f"No match found for species: {species}")
-                    return None
+                    raise PlantServiceException(
+                        error_code=PlantServiceErrorCode.NO_RESULTS_FOUND,
+                        message=f"No matching search results found for '{species}'",
+                        status_code=status.HTTP_404_NOT_FOUND
+                    )
                 
-                # Extract details
-                driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
-                content = wait.until(
-                    EC.presence_of_element_located((By.CSS_SELECTOR, 'lib-plant-details-full.ng-star-inserted'))
-                )
+                # Check if page contains full details or only summary
+                full_details_selector = 'lib-plant-details-full'
+                summary_selector = 'lib-plant-details-summary'
+                try:
+                    logger.info("Entered elements try block")
+                    driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
+                    
+                    element = wait.until(
+                        EC.presence_of_element_located((
+                            By.CSS_SELECTOR,
+                            f"{full_details_selector}, {summary_selector}"
+                        ))
+                    )
+                    logger.info(f"Element found: {element.tag_name}")
+                    
+                    # If only summary found, raise Exception
+                    if element.tag_name == summary_selector:
+                        raise PlantServiceException(
+                            error_code=PlantServiceErrorCode.NO_RESULTS_FOUND,
+                            message=f"RHS has no detailed information for '{species}', only a brief summary",
+                            status_code=status.HTTP_404_NOT_FOUND
+                        )
+                    
+                    # Otherwise wait for full details to render
+                    wait.until(
+                        EC.visibility_of_element_located((By.CSS_SELECTOR, f"{full_details_selector}"))
+                    )
+                    logger.info("Implicitly waiting 1 second")
+                    driver.implicitly_wait(1)
 
+                except TimeoutException:
+                    raise PlantServiceException(
+                        error_code=PlantServiceErrorCode.PARSING_ERROR,
+                        message="Timed out waiting for plant details element to load",
+                        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR
+                    )
+
+                # Extract details
                 soup = BeautifulSoup(driver.page_source, "lxml")
                 return self._extract_all_details(soup)
             
-            except Exception as e:
-                logger.error(f"Error scraping plant details: {str(e)}")
-                return None
+        except StaleElementReferenceException as e:
+            raise PlantServiceException(
+                error_code=PlantServiceErrorCode.PARSING_ERROR,
+                message="Page elements became stale during processing",
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+        
+        except Exception as e:
+            if isinstance(e, PlantServiceException):
+                raise
+            logger.debug(f"Exception: str{e}")
+            raise PlantServiceException(
+                error_code=PlantServiceErrorCode.PARSING_ERROR,
+                message="Failed to process plant details",
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                details={"error": str(e)}
+            )
             
     def _extract_all_details(self, soup: BeautifulSoup) -> PlantDetails:
+        """
+        Extract all plant details from the parsed HTML.
+
+        Args:
+            soup (BeautifulSoup): Parsed HTML of the RHS page for the plant species.
+
+        Returns:
+            PlantDetails: Structured plant information
+        """
         return PlantDetails(
             size=self._extract_size(soup),
             hardiness=self._extract_hardiness(soup),
@@ -281,26 +435,70 @@ class PlantScraper:
             pruning=self._extract_pruning(soup)
         )
 
-
+# Service-layer class
 class PlantDetailsRhsService:
+    """
+    Service layer for retrieving plant details from the RHS website.
+    Provides asynchronous access to plant information.
+    """
     @staticmethod
     async def retrieve_plant_details(plant: str) -> dict:
+        """
+        Asynchronously retrieve plant details from RHS website.
+
+        Args:
+            plant (str): Name of the plant species to search for.
+        
+        Returns:
+            dict: Structured plant information including size, hardiness, 
+                  soil requirements, position, cultivation tips and pruning.
+
+        Raises:
+            PlantServiceException: If retrieval fails for any reason.
+        """
         try:
             scraper = PlantScraper(base_url='https://www.rhs.org.uk/plants/search-results?query=')
-            details = await asyncio.to_thread(scraper.get_plant_details, plant)
+            
+            try:
+                details = await asyncio.to_thread(scraper.get_plant_details, plant)
+            except asyncio.TimeoutError:
+                raise PlantServiceException(
+                    error_code=PlantServiceErrorCode.TIMEOUT_ERROR,
+                    message="Operation timed out",
+                    status_code=status.HTTP_504_GATEWAY_TIMEOUT
+                )
             
             if details is None:
-                raise HTTPException(status_code=404, detail="Plant details not found")
+                raise PlantServiceException(
+                    error_code=PlantServiceErrorCode.NO_RESULTS_FOUND,
+                    message=f"No details found on RHS website for '{plant}'",
+                    status_code=status.HTTP_404_NOT_FOUND
+                )
             
-            return {
-                'size': details.size.to_dict() if details.size else None,
-                'hardiness': details.hardiness,
-                'soil': details.soil.to_dict() if details.soil else None,
-                'position': details.position.to_dict() if details.position else None,
-                'cultivation_tips': details.cultivation_tips,
-                'pruning': details.pruning,
-            }
+            try:
+                return {
+                    'size': details.size.to_dict() if details.size else None,
+                    'hardiness': details.hardiness,
+                    'soil': details.soil.to_dict() if details.soil else None,
+                    'position': details.position.to_dict() if details.position else None,
+                    'cultivation_tips': details.cultivation_tips,
+                    'pruning': details.pruning,
+                }
+            except Exception as e:
+                raise PlantServiceException(
+                    error_code=PlantServiceErrorCode.PARSING_ERROR,
+                    message="Failed to process plant details",
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    details={"error": str(e)}
+                )
 
         except Exception as e:
-            raise HTTPException(status_code=500, detail=str(e))
+            if isinstance(e, PlantServiceException):
+                raise
+            raise PlantServiceException(
+                error_code=PlantServiceErrorCode.SERVICE_ERROR,
+                message="Unexpectd error",
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                details={"error": str(e)}
+            )
     

--- a/backend_python/src/app/services/plant_identification.py
+++ b/backend_python/src/app/services/plant_identification.py
@@ -1,12 +1,31 @@
+"""Service to identify plant species based on uploaded image, using the PlantNet API."""
+
 import requests
 import json
+from fastapi import status
+from app.models import Organ
+from app.exceptions import PlantServiceErrorCode, PlantServiceException
 from app.config import settings
 import logging
+
 logger = logging.getLogger(__name__)
 
 class PlantIdentificationService:
     @staticmethod
-    def identify_plant(image_path: str, organ: str) -> dict:
+    def identify_plant(image_path: str, organ: Organ) -> dict:
+        """
+        Calls the PlantNet API to identify the plant.
+
+        Args:
+            image_path (str): Path for image to be uploaded
+            organ (Organ): Organ type to be passed to PlantNet API.
+        
+        Returns:
+            matches (dict): 3 most likely plants that match the image.
+
+        Raises:
+            PlantServiceException: If PlantNet cannot identify the species, or the service encounters an issue.     
+        """
         try:
             with open(image_path, 'rb') as image_data:
                 files = [('images', ((image_path), (image_data)))]
@@ -17,29 +36,64 @@ class PlantIdentificationService:
                     files=files, 
                     data=data
                 )
-                response.raise_for_status()
 
-                response_data = response.json()
-                results = response_data.get('results', [])
+                # If plant identified, return matches data
+                if response.status_code == 200:
+                    response_data = response.json()
+                    results = response_data.get('results', [])
+
+                    matches = {
+                        i: {
+                            'species': result['species']['scientificNameWithoutAuthor'],
+                            'genus': result['species']['genus']['scientificNameWithoutAuthor'],
+                            'score': result['score'],
+                            'commonNames': result['species']['commonNames']
+                        }
+                        for i, result in enumerate(results)
+                    }
+
+                    logging.info(f"Matches found: {len(matches)}")
+                    return {'matches': matches}
+                
+                # Handle 'Species Not Found'
+                elif response.status_code == 404:
+                    raise PlantServiceException(
+                        error_code=PlantServiceErrorCode.NO_RESULTS_FOUND,
+                        message="No matching species found",
+                        status_code=status.HTTP_404_NOT_FOUND
+                    )
+                # Handle 'Too Many Requests'
+                elif response.status_code == 429:
+                    raise PlantServiceException(
+                        error_code=PlantServiceErrorCode.SERVICE_ERROR,
+                        message="Rate limit exceeded",
+                        status_code=status.HTTP_429_TOO_MANY_REQUESTS
+                    )
+                # Handle other error codes
+                else:
+                    raise PlantServiceException(
+                        error_code=PlantServiceErrorCode.SERVICE_ERROR,
+                        message=f"Unexpected error occurred: {response.status_code}",
+                        status_code=response.status_code
+                    )
 
         except requests.RequestException as e:
-            logging.error(f"HTTP request failed: {e}")
-            return {}
+            raise PlantServiceException(
+                error_code=PlantServiceErrorCode.NETWORK_ERROR,
+                message=str(e),
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
         except json.JSONDecodeError:
-            logging.error("Failed to parse JSON response.")
-            return {}
-
-        matches = {
-            i: {
-                'species': result['species']['scientificNameWithoutAuthor'],
-                'genus': result['species']['genus']['scientificNameWithoutAuthor'],
-                'score': result['score'],
-                'commonNames': result['species']['commonNames']
-            }
-            for i, result in enumerate(results)
-        }
-
-        logging.info(f"Matches found: {len(matches)}")
-        return matches
+            raise PlantServiceException(
+                error_code=PlantServiceErrorCode.PARSING_ERROR,
+                message="Invalid response format",
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+        except Exception as e:
+            raise PlantServiceException(
+                error_code=PlantServiceErrorCode.SERVICE_ERROR,
+                message=str(e),
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
     
     

--- a/backend_python/src/app/utils/__init__.py
+++ b/backend_python/src/app/utils/__init__.py
@@ -1,0 +1,1 @@
+from .web_drivers import create_driver, CookieConsentHandler

--- a/backend_python/src/app/utils/web_drivers.py
+++ b/backend_python/src/app/utils/web_drivers.py
@@ -1,0 +1,82 @@
+from contextlib import contextmanager
+from typing import Generator
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.common.exceptions import  (
+    ElementNotInteractableException, 
+    TimeoutException, 
+    WebDriverException
+    )
+from selenium.webdriver.remote.webdriver import WebDriver
+from fastapi import status
+from app.exceptions import PlantServiceException, PlantServiceErrorCode
+import logging
+
+logger = logging.getLogger(__name__)
+
+@contextmanager
+def create_driver() -> Generator[tuple[WebDriver, WebDriverWait], None, None]:
+    """
+    Creates and manages a Chrome WebDriver session with appropriate error handling.
+
+    Yields:
+        Tuple[webdriver.Chrome, WebDriverWait]: Browser driver and wait object
+
+    Raises:
+        PlantServiceException: If browser initialisation fails
+    """
+    driver = webdriver.Chrome()
+    try:
+        driver.maximize_window()
+        wait = WebDriverWait(driver, timeout=5)
+        yield driver, wait
+    except WebDriverException as e:    
+        logger.info(f"WebDriverException: {str(e)}")
+        raise PlantServiceException(
+            error_code=PlantServiceErrorCode.BROWSER_ERROR,
+            message="Failed to initialise browser",
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            details={"error": str(e)}
+        )
+    finally:
+        logger.info("About to quit driver")
+        driver.quit()
+
+class CookieConsentHandler:
+    """Handles cookie consent popups across different website implementations."""
+    
+    BUTTON_CONFIGS = [
+        {"by": By.CLASS_NAME, "value": "onetrust-close-btn-handler"},
+        {"by": By.ID, "value": "onetrust-accept-btn-handler"},
+        {"by": By.CSS_SELECTOR, "value": "button[aria-label='Close']"}
+    ]
+
+    @classmethod
+    def handle(cls, driver: webdriver.Chrome, timeout: int=3) -> bool:
+        """
+        Attempts to handle cookie consent by trying multiple button configurations.
+
+        Args:
+            driver: Selenium WebDriver instance
+            timeout: Maximum time to wait for each button, defaults to 3 seconds
+
+        Returns:
+            bool: True if successfully handled, False if no buttons were found
+        """
+        for config in cls.BUTTON_CONFIGS:
+            try:
+                button = WebDriverWait(driver, timeout).until(
+                    EC.element_to_be_clickable((config["by"], config["value"]))
+                )
+                button.click()
+                logger.info(f"Successfully clicked cookie consent button: {config['value']}")
+                return True
+            except (TimeoutException, ElementNotInteractableException):
+                logger.debug(f"Could not find cookie button: {config['value']}")
+                continue
+        
+        logger.warning("Could not handle cookie consent - no matching buttons found")
+        return False
+    

--- a/frontend_flutter/pubspec.yaml
+++ b/frontend_flutter/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-
   cupertino_icons: ^1.0.8
   image_picker: ^1.1.2
   http: ^1.2.2


### PR DESCRIPTION
Frontend: changed requests to use Dio (instead of flutter_http);
Frontend: made image reset optional in _reset function;
Frontend: reordered widget definitions;
Backend: added 'Organ' Enum to match PlantNet API requirement;
Backend: created separate 'exceptions' module for centralised error-handling, including custom error codes and custom Exception;
Backend: created separate 'models' module for centralised pydantic models and dataclasses;
Backend: created separate 'utils' module for web driver utilities (driver creation, cookie-handling;
Backend: added exceptions handler in main.py;
Backend: error-handling for identification service, based on responses from PlantNet;
Backend: error-handling for RhsDetails service;
Backend: if can't find species strictly on RHS, also searches for "species + (";
Backend: error-handling for case when only RHS summary available;
Backend: added schema and request/response models for API docs;